### PR TITLE
Cast Long to String instead of Integer

### DIFF
--- a/src/main/scala/tableau/TableauDataFrame.scala
+++ b/src/main/scala/tableau/TableauDataFrame.scala
@@ -47,7 +47,7 @@ class TableauDataFrameImplicity(df:DataFrame) extends Serializable {
     dataType match  {
       case StringType => Type.CHAR_STRING
       case IntegerType => Type.INTEGER
-      case LongType => Type.INTEGER
+      case LongType => Type.CHAR_STRING
       case DoubleType => Type.DOUBLE
       case BooleanType => Type.BOOLEAN
       case DateType => Type.DATETIME
@@ -85,14 +85,14 @@ class TableauDataFrameImplicity(df:DataFrame) extends Serializable {
         if (dataFrameRow.get(columnIndex) == null){
           row.setNull(i)
         } else {
-          columnType match { 
-            case (Type.CHAR_STRING) => row.setCharString(i, dataFrameRow.getString(columnIndex))
-            case (Type.INTEGER) => 
+          columnType match {
+            case (Type.CHAR_STRING) =>
               try{
-                row.setInteger(i, dataFrameRow.getInt(columnIndex))
+                row.setCharString(i, dataFrameRow.getString(columnIndex))
               } catch{
-                case e:java.lang.ClassCastException => row.setInteger(i, dataFrameRow.getLong(columnIndex).toInt)
+                case e:java.lang.ClassCastException => row.setCharString(i, dataFrameRow.getLong(columnIndex).toString)
               }
+            case (Type.INTEGER) => row.setInteger(i, dataFrameRow.getInt(columnIndex))
             case (Type.DOUBLE) => {
               val d = dataFrameRow.getDouble(columnIndex)
               row.setDouble(i, d)

--- a/src/main/scala/tableau/TableauDataFrame.scala
+++ b/src/main/scala/tableau/TableauDataFrame.scala
@@ -55,10 +55,10 @@ class TableauDataFrameImplicity(df:DataFrame) extends Serializable {
   }
   
   private def makeTableDefinition(columnsTypes:Seq[(String, Type)]):TableDefinition = {
-    val tableDef:TableDefinition = new TableDefinition();
-    tableDef.setDefaultCollation(Collation.PT_BR);
+    val tableDef:TableDefinition = new TableDefinition()
+    tableDef.setDefaultCollation(Collation.PT_BR)
     columnsTypes.foreach((tableDef.addColumn _).tupled)
-    tableDef;
+    tableDef
   }
 
   private def getParquetColumnsIndexes(colTypes:Seq[(String, Type)], df: org.apache.spark.sql.DataFrame) = {

--- a/src/main/scala/tableau/TableauDataFrame.scala
+++ b/src/main/scala/tableau/TableauDataFrame.scala
@@ -21,14 +21,14 @@ class TableauDataFrameImplicity(df:DataFrame) extends Serializable {
     ExtractAPI.initialize()
 
     val colTypes = columnTypes()
-    val columnIndexes:Seq[(Int, Type, Int)] = getParquetColumnsIndexes(colTypes, df)
+    val columnIndexes:Seq[(Int, Type, Int)] = getColumnsIndexes(colTypes, df)
     df.repartition(1).foreachPartition { it =>
       logger.info("Creating tableau table")
       val table = createTableauTable(colTypes, filename)
       logger.info("Tableau table created")
       val tableDef = table.getTableDefinition()
       logger.info("Inserting rows in Tableau table")
-      it.map(createTableauRowFromParquetRow(tableDef, columnIndexes, _))
+      it.map(createTableauRowFromDataFrameRow(tableDef, columnIndexes, _))
         .foreach(table.insert)
     }
     logger.info("Tableau extractor created '{}'", filename)
@@ -61,7 +61,7 @@ class TableauDataFrameImplicity(df:DataFrame) extends Serializable {
     tableDef
   }
 
-  private def getParquetColumnsIndexes(colTypes:Seq[(String, Type)], df: org.apache.spark.sql.DataFrame) = {
+  private def getColumnsIndexes(colTypes:Seq[(String, Type)], df: org.apache.spark.sql.DataFrame) = {
     colTypes.zipWithIndex.map{ 
       case((columnName, columnType), i) => (i, columnType, df.schema.fieldIndex(columnName))
     }
@@ -78,30 +78,30 @@ class TableauDataFrameImplicity(df:DataFrame) extends Serializable {
     table
   }
 
-  private def createTableauRowFromParquetRow(tableDef:TableDefinition, columnIndexes:Seq[(Int, Type, Int)], parquetRow:org.apache.spark.sql.Row):Row = {
+  private def createTableauRowFromDataFrameRow(tableDef:TableDefinition, columnIndexes:Seq[(Int, Type, Int)], dataFrameRow:org.apache.spark.sql.Row):Row = {
     val row:Row = new Row(tableDef)
     columnIndexes.foreach{ 
       case(i, columnType, columnIndex) => 
-        if (parquetRow.get(columnIndex) == null){
+        if (dataFrameRow.get(columnIndex) == null){
           row.setNull(i)
         } else {
           columnType match { 
-            case (Type.CHAR_STRING) => row.setCharString(i, parquetRow.getString(columnIndex))
+            case (Type.CHAR_STRING) => row.setCharString(i, dataFrameRow.getString(columnIndex))
             case (Type.INTEGER) => 
               try{
-                row.setInteger(i, parquetRow.getInt(columnIndex))
+                row.setInteger(i, dataFrameRow.getInt(columnIndex))
               } catch{
-                case e:java.lang.ClassCastException => row.setInteger(i, parquetRow.getLong(columnIndex).toInt)
+                case e:java.lang.ClassCastException => row.setInteger(i, dataFrameRow.getLong(columnIndex).toInt)
               }
             case (Type.DOUBLE) => {
-              val d = parquetRow.getDouble(columnIndex)
+              val d = dataFrameRow.getDouble(columnIndex)
               row.setDouble(i, d)
             
             }
-            case (Type.BOOLEAN) => row.setBoolean(i, parquetRow.getBoolean(columnIndex))
+            case (Type.BOOLEAN) => row.setBoolean(i, dataFrameRow.getBoolean(columnIndex))
             case (Type.DATETIME) => {
               val dt = java.util.Calendar.getInstance
-              dt.setTime(new java.util.Date(parquetRow.getLong(columnIndex)))
+              dt.setTime(new java.util.Date(dataFrameRow.getLong(columnIndex)))
               row.setDateTime(i, dt.get(java.util.Calendar.YEAR),
                                  dt.get(java.util.Calendar.MONTH) + 1,
                                  dt.get(java.util.Calendar.DAY_OF_MONTH),


### PR DESCRIPTION
Let's cast Long to String instead of Integer. In addition I renamed variables and functions containing parquet, your implementation works for any dataframe independent of the data format.