### PR TITLE
use function setLongInteger instead of setInteger. This fixes #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ build
 .cache-tests
 *.tde
 *.log
+
+# Ignore Mac DS_Store files
+.DS_Store
+
+# Ignore IDEA project folder
+.idea
+

--- a/src/main/scala/tableau/TableauDataFrame.scala
+++ b/src/main/scala/tableau/TableauDataFrame.scala
@@ -56,10 +56,10 @@ class TableauDataFrameImplicity(df:DataFrame) extends Serializable {
   }
   
   private def makeTableDefinition(columnsTypes:Seq[(String, Type)]):TableDefinition = {
-    val tableDef:TableDefinition = new TableDefinition();
-    tableDef.setDefaultCollation(Collation.PT_BR);
+    val tableDef:TableDefinition = new TableDefinition()
+    tableDef.setDefaultCollation(Collation.PT_BR)
     columnsTypes.foreach((tableDef.addColumn _).tupled)
-    tableDef;
+    tableDef
   }
 
   private def getParquetColumnsIndexes(colTypes:Seq[(String, Type)], df: org.apache.spark.sql.DataFrame) = {
@@ -81,7 +81,7 @@ class TableauDataFrameImplicity(df:DataFrame) extends Serializable {
 
   private def createTableauRowFromParquetRow(tableDef:TableDefinition, columnIndexes:Seq[(Int, Type, Int)], parquetRow:org.apache.spark.sql.Row):Row = {
     val row:Row = new Row(tableDef)
-    columnIndexes.foreach{ 
+    columnIndexes.foreach{
       case(i, columnType, columnIndex) => 
         if (parquetRow.get(columnIndex) == null){
           row.setNull(i)
@@ -90,15 +90,11 @@ class TableauDataFrameImplicity(df:DataFrame) extends Serializable {
             case (Type.CHAR_STRING) => row.setCharString(i, parquetRow.getString(columnIndex))
             case (Type.INTEGER) => 
               parquetRow.get(columnIndex) match {
-                case in: java.lang.Integer => row.setInteger(i, in.intValue())
-                case lo: java.lang.Long => row.setInteger(i, lo.longValue().toInt)
-                case sh: java.lang.Short => row.setInteger(i, sh.shortValue().toInt)
+                case in: scala.Int => row.setInteger(i, in.toInt)
+                case lo: scala.Long => row.setLongInteger(i, lo.toLong)
+                case sh: scala.Short => row.setInteger(i, sh.toShort.toInt)
               }
-            case (Type.DOUBLE) => {
-              val d = parquetRow.getDouble(columnIndex)
-              row.setDouble(i, d)
-            
-            }
+            case (Type.DOUBLE) => row.setDouble(i, parquetRow.getDouble(columnIndex))
             case (Type.BOOLEAN) => row.setBoolean(i, parquetRow.getBoolean(columnIndex))
             case (Type.DATETIME) => {
               val dt = java.util.Calendar.getInstance

--- a/src/test/scala/tableau/TestDataframeToTableau.scala
+++ b/src/test/scala/tableau/TestDataframeToTableau.scala
@@ -17,7 +17,7 @@ object TestDataframeToTableau {
   @BeforeClass
   def setup(): Unit = {
     val sparkConf = new SparkConf()
-      .setAppName("Test Spark Streaming")
+      .setAppName("Test Dataframe to TDE")
       .setMaster("local[*]")
     sc = new SparkContext(sparkConf)
   }
@@ -43,6 +43,22 @@ class TestDataframeToTableau {
     assertEquals(5, numDf.count)
     numDf.saveToTableau("numbers.tde")
     val f = new File("numbers.tde")
+    assertTrue(f.exists())
+    f.delete()
+  }
+
+  @Test
+  def testSaveLongNumbersToExtractor():Unit = {
+    val sql = new SQLContext(TestDataframeToTableau.sc)
+    import sql.implicits._
+    import TableauDataFrame._
+
+    val numList = List(1111111111L,-222222222222L,3333333333L)
+    val df = TestDataframeToTableau.sc.parallelize(numList).toDF
+    val numDf = df.select(df("_1").alias("long_num"))
+    assertEquals(3, numDf.count)
+    numDf.saveToTableau("long-numbers.tde")
+    val f = new File("long-numbers.tde")
     assertTrue(f.exists())
     f.delete()
   }


### PR DESCRIPTION
**Tableau Extract API** supports **long**. I added a test to demonstrate the long support. It'd be great if we find a way to verify the content of the generated TDE files.